### PR TITLE
Make Telegram environment checks dynamic

### DIFF
--- a/src/env.js
+++ b/src/env.js
@@ -3,14 +3,24 @@
  * @module env
  */
 
-/** Whether the app runs inside Telegram WebView. */
-export const isTelegram = typeof window !== 'undefined' && !!window.Telegram && !!window.Telegram.WebApp;
-
 /** Telegram WebApp instance or null. */
-export const tg = isTelegram ? window.Telegram.WebApp : null;
+export function tg() {
+  if (typeof window === 'undefined') return null;
+  return window.Telegram && window.Telegram.WebApp ? window.Telegram.WebApp : null;
+}
+
+/** Whether the app runs inside Telegram WebView. */
+export function isTelegram() {
+  return tg() !== null;
+}
 
 /** Client version string. */
-export const version = tg ? tg.version : 'N/A';
+export function version() {
+  const app = tg();
+  return app ? app.version : 'N/A';
+}
 
 /** Human readable environment name. */
-export const environment = isTelegram ? 'Telegram' : 'Browser';
+export function environment() {
+  return isTelegram() ? 'Telegram' : 'Browser';
+}

--- a/src/main.js
+++ b/src/main.js
@@ -5,13 +5,14 @@ import { initUI, t, updateHeader } from './ui.js';
 initUI().then(setup);
 
 function setup() {
-  if (isTelegram) {
-    document.getElementById('raw-data').textContent = api.initDataRaw;
-    document.getElementById('parsed-data').textContent = JSON.stringify(api.initData, null, 2);
-    tg.onEvent('viewportChanged', updateWindowInfo);
-    tg.onEvent('themeChanged', updateThemeInfo);
-    tg.onEvent('mainButtonClicked', () => alert(t('on_click')));
-    tg.onEvent('backButtonClicked', () => alert(t('on_click')));
+  if (isTelegram()) {
+    document.getElementById('raw-data').textContent = api.initDataRaw();
+    document.getElementById('parsed-data').textContent = JSON.stringify(api.initData(), null, 2);
+    const app = tg();
+    app.onEvent('viewportChanged', updateWindowInfo);
+    app.onEvent('themeChanged', updateThemeInfo);
+    app.onEvent('mainButtonClicked', () => alert(t('on_click')));
+    app.onEvent('backButtonClicked', () => alert(t('on_click')));
     updateWindowInfo();
     updateThemeInfo();
   } else {
@@ -96,15 +97,17 @@ function bindEvents() {
 }
 
 function updateWindowInfo() {
-  if (!isTelegram) return;
-  document.getElementById('viewport').textContent = tg.viewportHeight;
-  document.getElementById('stable').textContent = tg.stableHeight;
-  document.getElementById('expanded').textContent = tg.isExpanded;
+  const app = tg();
+  if (!app) return;
+  document.getElementById('viewport').textContent = app.viewportHeight;
+  document.getElementById('stable').textContent = app.stableHeight;
+  document.getElementById('expanded').textContent = app.isExpanded;
 }
 
 function updateThemeInfo() {
-  if (!isTelegram) return;
-  document.getElementById('color-scheme').textContent = tg.colorScheme;
-  document.getElementById('theme-params').textContent = JSON.stringify(tg.themeParams);
+  const app = tg();
+  if (!app) return;
+  document.getElementById('color-scheme').textContent = app.colorScheme;
+  document.getElementById('theme-params').textContent = JSON.stringify(app.themeParams);
 }
 

--- a/src/tg-api.js
+++ b/src/tg-api.js
@@ -1,4 +1,4 @@
-import { isTelegram, tg, version } from './env.js';
+import { tg, version } from './env.js';
 
 /**
  * Show a common message when feature used outside Telegram.
@@ -13,117 +13,148 @@ function unavailable() {
  * @returns {boolean}
  */
 function ensure(min) {
-  if (!isTelegram) {
+  const app = tg();
+  if (!app) {
     unavailable();
-    return false;
+    return null;
   }
-  if (min && parseFloat(version) < min) {
+  if (min && parseFloat(version()) < min) {
     alert(`Requires Telegram ${min}+`);
-    return false;
+    return null;
   }
-  return true;
+  return app;
 }
 
-export const initDataRaw = isTelegram ? tg.initData : '';
-export const initData = isTelegram ? tg.initDataUnsafe : {};
+export function initDataRaw() {
+  const app = tg();
+  return app ? app.initData : '';
+}
+export function initData() {
+  const app = tg();
+  return app ? app.initDataUnsafe : {};
+}
 
 export function ready() {
-  if (ensure()) tg.ready();
+  const app = ensure();
+  app?.ready();
 }
 
 export function expand() {
-  if (ensure()) tg.expand();
+  const app = ensure();
+  app?.expand();
 }
 
 export function close() {
-  if (ensure()) tg.close();
+  const app = ensure();
+  app?.close();
 }
 
 export function setHeaderColor(color) {
-  if (ensure()) tg.setHeaderColor(color);
+  const app = ensure();
+  app?.setHeaderColor(color);
 }
 
 export function setBackgroundColor(color) {
-  if (ensure()) tg.setBackgroundColor(color);
+  const app = ensure();
+  app?.setBackgroundColor(color);
 }
 
 export function showAlert(text) {
-  if (ensure()) tg.showAlert(text);
+  const app = ensure();
+  app?.showAlert(text);
 }
 
 export function showConfirm(text) {
-  if (!ensure()) return Promise.resolve(false);
-  return tg.showConfirm(text);
+  const app = ensure();
+  if (!app) return Promise.resolve(false);
+  return app.showConfirm(text);
 }
 
 export function showPopup(params) {
-  if (ensure()) tg.showPopup(params);
+  const app = ensure();
+  app?.showPopup(params);
 }
 
 export function hapticImpact(style) {
-  if (ensure()) tg.HapticFeedback.impactOccurred(style);
+  const app = ensure();
+  app?.HapticFeedback?.impactOccurred(style);
 }
 
 export function hapticNotification(type) {
-  if (ensure()) tg.HapticFeedback.notificationOccurred(type);
+  const app = ensure();
+  app?.HapticFeedback?.notificationOccurred(type);
 }
 
 export function readTextFromClipboard() {
-  if (!ensure(6.7)) return Promise.resolve('');
-  return tg.readTextFromClipboard();
+  const app = ensure(6.7);
+  if (!app) return Promise.resolve('');
+  return app.readTextFromClipboard();
 }
 
 export function showScanQrPopup(cb) {
-  if (!ensure(6.4)) return;
-  tg.showScanQrPopup({ text: 'scan' }, cb);
+  const app = ensure(6.4);
+  if (!app) return;
+  app.showScanQrPopup({ text: 'scan' }, cb);
 }
 
 export function openLink(url) {
-  if (ensure()) tg.openLink(url);
+  const app = ensure();
+  app?.openLink(url);
 }
 
 export function openTelegramLink(url) {
-  if (ensure()) tg.openTelegramLink(url);
+  const app = ensure();
+  app?.openTelegramLink(url);
 }
 
 export function requestWriteAccess() {
-  if (ensure()) tg.requestWriteAccess();
+  const app = ensure();
+  app?.requestWriteAccess();
 }
 
 export function requestContact() {
-  if (ensure()) tg.requestContact();
+  const app = ensure();
+  app?.requestContact();
 }
 
 export function mainButtonShow() {
-  if (ensure()) tg.MainButton.show();
+  const app = ensure();
+  app?.MainButton.show();
 }
 
 export function mainButtonHide() {
-  if (ensure()) tg.MainButton.hide();
+  const app = ensure();
+  app?.MainButton.hide();
 }
 
 export function mainButtonEnable() {
-  if (ensure()) tg.MainButton.enable();
+  const app = ensure();
+  app?.MainButton.enable();
 }
 
 export function mainButtonDisable() {
-  if (ensure()) tg.MainButton.disable();
+  const app = ensure();
+  app?.MainButton.disable();
 }
 
 export function mainButtonSetText(text) {
-  if (ensure()) tg.MainButton.setText(text);
+  const app = ensure();
+  app?.MainButton.setText(text);
 }
 
 export function mainButtonSetColor(color) {
-  if (ensure()) tg.MainButton.setParams({ color });
+  const app = ensure();
+  app?.MainButton.setParams({ color });
 }
 
 export function backButtonShow() {
-  if (ensure()) tg.BackButton.show();
+  const app = ensure();
+  app?.BackButton.show();
 }
 
 export function backButtonHide() {
-  if (ensure()) tg.BackButton.hide();
+  const app = ensure();
+  app?.BackButton.hide();
 }
 
 export { ensure };

--- a/src/ui.js
+++ b/src/ui.js
@@ -54,9 +54,9 @@ export function updateHeader() {
   const envEl = document.getElementById('env-info');
   const themeEl = document.getElementById('theme-info');
   const verEl = document.getElementById('version-info');
-  if (envEl) envEl.textContent = `${t('env_label')}: ${environment}`;
+  if (envEl) envEl.textContent = `${t('env_label')}: ${environment()}`;
   if (themeEl) themeEl.textContent = `${t('theme_label')}: ${t('theme_' + currentTheme.replace('-', ''))}`;
-  if (verEl) verEl.textContent = `${t('version_label')}: ${version}`;
+  if (verEl) verEl.textContent = `${t('version_label')}: ${version()}`;
 }
 
 /** Initialize UI controls. */


### PR DESCRIPTION
## Summary
- Detect Telegram WebApp at runtime and expose dynamic helpers
- Update API, UI, and main logic to use new helpers and run features when `Telegram.WebApp` is present

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check src/env.js src/main.js src/tg-api.js src/ui.js`


------
https://chatgpt.com/codex/tasks/task_e_68bd6cc48e948324baf0717d8fd8a68a