### PR TITLE
fix: wrap long strings in window theme section

### DIFF
--- a/index.html
+++ b/index.html
@@ -17,6 +17,7 @@
     pre{background:rgba(0,0,0,0.5);padding:0.5rem;border-radius:12px;overflow-x:auto;}
     .split{display:flex;flex-wrap:wrap;gap:1rem;}
     .btn-group{display:flex;flex-wrap:wrap;align-items:center;}
+    #window-theme span{word-break:break-all;}
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- prevent long values from overflowing window theme info container

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7a452cb88324b21188a8667cf1ed