### PR TITLE
Allow wrapping in init data blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,7 +14,7 @@
     button{border:none;padding:0.5rem 1rem;margin:0.25rem;border-radius:12px;background:var(--accent);color:var(--fg);box-shadow:0 0 8px var(--accent-glow);cursor:pointer;transition:0.2s;}
     button:hover{opacity:0.9;box-shadow:0 0 12px var(--accent-glow);} 
     button:active{opacity:0.8;box-shadow:0 0 2px var(--accent-glow);} 
-    pre{background:rgba(0,0,0,0.5);padding:0.5rem;border-radius:12px;overflow-x:auto;}
+    pre{background:rgba(0,0,0,0.5);padding:0.5rem;border-radius:12px;overflow-x:auto;white-space:pre-wrap;word-break:break-all;}
     .split{display:flex;flex-wrap:wrap;gap:1rem;}
     .btn-group{display:flex;flex-wrap:wrap;align-items:center;}
     #window-theme span{word-break:break-all;}


### PR DESCRIPTION
## Summary
- ensure raw and parsed init data can wrap instead of overflowing by adjusting `pre` styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7be4038c8324839534854b592f33